### PR TITLE
feat(login-service): Added support for configuring user-specific TTL

### DIFF
--- a/etc/login-service.yaml
+++ b/etc/login-service.yaml
@@ -1,5 +1,8 @@
 cookiedomain: .mycorp.io
 tokenttl: 20h
+usertokenttls:
+  # User-specific TTLs -- will override tokenttl
+  privileged.user@mycorp.io: 336h  # 2 weeks
 defaulttokenprovider: simple
 loginsessionttl: 5m
 allowedredirectdomain: .mycorp.io


### PR DESCRIPTION
It is now possible to configure TTLs specific to certain users by adding them to `usertokenttls` in login-service.yaml.